### PR TITLE
Fix: Correct VAD import statement

### DIFF
--- a/src/components/TestAgentDialog.tsx
+++ b/src/components/TestAgentDialog.tsx
@@ -13,7 +13,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { fetchAIResponse } from "@/api/chat";
 import { streamTextToSpeech } from "@/api/elevenlabs";
-import * as vad from "@ricky0123/vad-web";
+import { MicVAD } from "@ricky0123/vad-web";
 import { AudioVisualizer } from "react-audio-visualize";
 
 interface Message {
@@ -59,12 +59,12 @@ export default function TestAgentDialog({ open, onOpenChange, selectedVoice }: T
   const [error, setError] = useState<string | null>(null);
   const [isMuted, setIsMuted] = useState(false);
   const [useVAD, setUseVAD] = useState(false);
-  const vadRef = useRef<vad.MicVAD | null>(null);
+  const vadRef = useRef<MicVAD | null>(null);
 
   useEffect(() => {
     if (useVAD) {
       const initVAD = async () => {
-        const myvad = await vad.MicVAD.new({
+        const myvad = await MicVAD.new({
           onSpeechStart: () => {
             startRecording();
           },


### PR DESCRIPTION
This commit fixes a bug where the `@ricky0123/vad-web` package was not being resolved correctly by Vite. The import statement has been changed to correctly import the `MicVAD` class.